### PR TITLE
Actualizar: Configuración de eslint para prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,11 @@ module.exports = {
     es2021: true,
     node: true
   },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
   extends: [
     'plugin:react/recommended',
     'standard'
@@ -20,6 +25,7 @@ module.exports = {
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
-    'space-before-function-paren': 'off'
+    'space-before-function-paren': 'off',
+    'multiline-ternary': 'off'
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,29 @@
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# package-lock.json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write ./src"
   },
   "dependencies": {
     "next": "13.2.4",


### PR DESCRIPTION
- Se agregaron configuraciones para utilizar Eslint y Prettier sin conflictos
- Se agregó el archivo .prettierignore para evitar del formateo de los archivos en los que no es necesario